### PR TITLE
Introducing Pesto, a mobile first, retina-ready, clean custom style

### DIFF
--- a/Pesto.css
+++ b/Pesto.css
@@ -11,6 +11,12 @@
   -webkit-box-sizing: border-box;
   box-sizing: border-box; }
 
+/*!
+   Fonts used are Adobe's Source Sans Pro and Source Code Pro, which are:
+   Copyright © 2010, Adobe Systems, Inc. (http://www.adobe.com/)
+   Licensed under the SIL Open Font License, Version 1.1:
+   http://www.adobe.com/type/browser/legal/pdfs/OpenFontLicense.pdf
+*/
 @media (-webkit-max-device-pixel-ratio: 1.49), (max-resolution: 143dpi) {
   @font-face {
     font-family: "Source Sans Pro";

--- a/Pesto.scss
+++ b/Pesto.scss
@@ -42,10 +42,12 @@ $color-ui-light   : lighten($color-text-light, 11%);
 // Font Embeds
 // ============
 
-// Fonts used are Adobe's Source Sans Pro and Source Code Pro, which are:
-// Copyright © 2010, Adobe Systems, Inc. (http://www.adobe.com/)
-// Licensed under the SIL Open Font License, Version 1.1:
-// http://www.adobe.com/type/browser/legal/pdfs/OpenFontLicense.pdf
+/*!
+   Fonts used are Adobe's Source Sans Pro and Source Code Pro, which are:
+   Copyright © 2010, Adobe Systems, Inc. (http://www.adobe.com/)
+   Licensed under the SIL Open Font License, Version 1.1:
+   http://www.adobe.com/type/browser/legal/pdfs/OpenFontLicense.pdf
+*/
 
 // Non-retina regular weight fonts (use 300)
 @media (-webkit-max-device-pixel-ratio: 1.49),


### PR DESCRIPTION
New Marked custom style forked from _Kult_ by [Peter Sziebig (@bigpe)](https://twitter.com/bigpe). Currently in use to style [my résumé](http://www.acusti.ca/resume/). See [its repo](https://github.com/acusti/Custom-Marked-Styles) for details.
