### PR TITLE
Added Pandoctor style

### DIFF
--- a/Academia.css
+++ b/Academia.css
@@ -10,7 +10,7 @@ body {
     -webkit-font-smoothing: antialiased;
     font-style: normal;
     font-size: 12pt;
-    font: normal 1em "Palatino", Serif;
+    font-family; "Hoefler Text", Palatino, Georgia, Times, Serif;
 	text-align: justify;
 	hyphens: auto;
 	width: 825px;
@@ -19,7 +19,7 @@ body {
 
 
 li {
-    font-size: 100%;
+    font-size: 110%;
 }
 
 li li {


### PR DESCRIPTION
This style offers a clean, double spaced, serifed text with readable margins. It is meant to nearly precisely mimic the .docx output if one uses my `reference.docx` file with pandoc when converting from MD to DOCX (for more info, see [here](https://github.com/smargh/pandoc-templates)). Thus, this style allows you to see what your final .docx will look like, without having to constantly generate the file and view it. 
