### PR TITLE
Avenue

### DIFF
--- a/Avenue.css
+++ b/Avenue.css
@@ -7,62 +7,191 @@ Author: Bram de Haan <http://atelierbramdehaan.nl>
 Description: modern retro
  */
 
-* {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
-}
+/* ::Base styles Almost exclusively single element selectors */
 html {
   font-size: 16px;
+}
+body {
+  font: 100%/1.375 AvenirNext-Regular, Futura, "Century Gothic", AppleGothic, Corbel, "Myriad Pro", "Lucida Grande", "Trebuchet Ms", sans-serif;
+  color: #111;
+  padding: 0 5% 1rem;
+  -webkit-font-smoothing: antialiased;
+}
+a {
+  color: crimson;
+}
+a:hover, a:focus, a:active {
+  color: #ff2450;
+}
+h1, h2, h3, h4, h5, h6 {
+  font-family: AvenirNextCondensed-DemiBold, AvenirNext-Regular, Avenir-Black, Futura, "Century Gothic", AppleGothic, Corbel, "Myriad Pro", "Lucida Grande", "Trebuchet Ms", sans-serif;
+  margin: 0 1rem;
+  padding: .5em 0 0;
+}
+h1 {
+  font-size: 2.25rem;
+  line-height: 1.11111;
+}
+h2 {
+  font-size: 1.875rem;
+  line-height: 1.33333;
+}
+h3 {
+  font-size: 1.375rem;
+  line-height: 1.45455;
+}
+h4 {
+  font-size: 1.25rem;
+  line-height: 1.2;
+}
+h5, dl {
+  font-size: 1.125rem;
+  line-height: 1.33333;
+}
+h6 {
+  font-size: 1rem;
+  line-height: 1.5;
+}
+pre, label {
+  font-size: 1rem;
+  line-height: 1.5;
+}
+p {
+  font-size: 1.25em;
+  margin: 0 1rem;
+  padding: .5em 0;
+}
+h2 + p,
+h3 + p,
+h4 + p,
+h5 + p {
+  padding-top: .125em;
+  margin-top: 1px;
+  border-top: 3px double #888;
+}
+ol, ul {
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-top: .5em;
+  margin-bottom: 1em;
+}
+ul {
+  margin-left: -1.5rem;
+}
+ul ul,ul ol {
+  margin-bottom: .4em;
+}
+ul {
+  list-style-position: outside;
+  list-style-type: square;
+}
+ol {
+  list-style-position: outside;
+  list-style-type: decimal;
+}
+ul li>p,
+ol li>p {
+  margin-left: 0;
+  padding: 0;
+}
+pre,
+code {
+  font-family: Consolas, Menlo, Monaco, monospace !important;
+}
+pre {
+  margin: 1.5em 1rem;
+  font-size: .875rem;
+  white-space: pre-wrap;
+}
+pre code {
+  padding: 1rem;
+  display: inline-block;
+}
+p>code,
+ul>code {
+  font-size: .875em;
+  margin: 0;
+  border: 1px solid #ddd;
+  background-color: #f8f8f8;
+  border-radius: 3px;
+  padding: 2px 0 0 0;
+  color: #b31940;
+}
+p>code:before,
+p>code:after,
+ul>code:before,
+ul>code:after {
+  content: "\00a0";
+  letter-spacing: -0.2em;
+}
+strong, b, dt {
+  font-family: AvenirNext-Medium, AvenirNext-Bold, AvenirNextCondensed-DemiBold, Avenir-Black, Futura, "Century Gothic", AppleGothic, Corbel, "Myriad Pro", "Lucida Grande", "Trebuchet Ms", sans-serif;
+  font-weight: 600;
+}
+em, q, blockquote, blockquote p  {
+  font-family: AvenirNext-MediumItalic, AvenirNext-BoldItalic, Avenir-MediumOblique, Futura, "Century Gothic", AppleGothic, Corbel, "Myriad Pro", "Lucida Grande", "Trebuchet Ms", sans-serif;
+  font-style: italic;
+}
+i {
+  font-family: AvenirNext-Italic, Avenir-Oblique, Futura, "Century Gothic", AppleGothic, Corbel, "Myriad Pro", "Lucida Grande", "Trebuchet Ms", sans-serif;
+  font-style: italic;
+}
+blockquote {
+  border-left: .33em solid #aaa;
+  padding: .75em 1.5em;
+  margin: 1em 0 2em 1rem;
+  background-color: #f7f7f7;
+  color: #444;
+  box-shadow: 1px 1px 0 hsla(0,0%,0%,.125);
+}
+blockquote p {
+  margin: 0;
+}
+hr {
+  padding: 1px;
+  border: 1px solid #ccc;
+  background-color: #ddd;
+  box-sizing: content-box;
+  height: 0;
 }
 table {
   border: 1px solid rgba(0,0,0,0.25);
   border-collapse: collapse;
   display: table;
   empty-cells: hide;
-  margin: -1px 0 23px;
+  margin: 1em 0 2em;
   padding: 0;
   table-layout: fixed;
 }
-
 caption {
   display: table-caption;
   font-weight: 700;
 }
-
 col {
   display: table-column;
 }
-
 colgroup {
   display: table-column-group;
 }
-
 tbody {
   display: table-row-group;
 }
-
 tfoot {
   display: table-footer-group;
 }
-
 thead {
   display: table-header-group;
 }
-
 td,th {
   display: table-cell;
 }
-
 tr {
   display: table-row;
 }
-
 table th,table td {
   font-size: 1.1em;
   padding: 1em;
 }
-
 table thead {
   background: rgba(0,0,0,0.15);
   border: 1px solid rgba(0,0,0,0.15);
@@ -76,14 +205,12 @@ table tfoot {
     border: 1px solid rgba(0,0,0,0.15);
     border-top: 1px solid rgba(0,0,0,0.2);
 }
-
 table tr:nth-child(odd),table th:nth-child(odd),table td:nth-child(odd) {
   background: rgba(255,255,255,0.06);
 }
 table tr:nth-child(even),table td:nth-child(even) {
   background: rgba(200,200,200,0.25);
 }
-
 q, blockquote {
   quotes: none;
 }
@@ -101,24 +228,14 @@ button, input, select, textarea {
   font-size: 100%;
   margin: 0;
   vertical-align: baseline;
-  /* vertical-align: middle; */
 }
 button, input[type="button"], input[type="reset"], input[type="submit"] {
   cursor: pointer;
-  /* overflow: visible; */
-}
-button::-moz-focus-inner, input::-moz-focus-inner {
-  border: 0;
-  padding: 0;
 }
 textarea {
   overflow: auto;
   vertical-align: top;
   resize: vertical;
-}
-body {
-  -webkit-font-smoothing: antialiased;
-  padding: 0 !important;
 }
 #wrapper {
   margin-bottom: 0;
@@ -129,13 +246,9 @@ img,
   height: auto;
 }
 dd {
+  padding-left: 0;
+  margin-left: 1rem;
   margin-bottom: 1em;
-}
-li > p:first-child {
-  margin: 0;
-}
-dd {
-  padding-left: 1.4em;
 }
 table tr:nth-child(even) {
   background: rgba(200, 200, 200, 0.25);
@@ -144,6 +257,9 @@ figure {
   display: inline-block;
   position: relative;
   margin: 1em 0 2em;
+  padding: 1em;
+  background-color: #e6e6e6;
+  border: 1px solid #ddd;
 }
 figcaption {
   font-family: AvenirNext-Italic, AvenirNext-Regular, Futura, "Century Gothic", AppleGothic, Corbel, "Myriad Pro", "Lucida Grande", "Trebuchet Ms", sans-serif;
@@ -180,13 +296,10 @@ sub {
 .footnotes p {
   font-size: 1.9ex;
 }
-ul ul {
-  margin-left: 1em;
-}
 
 ul ul,
 ol ol {
-  margin-left: 1em;
+  margin-left: -1em;
 }
 li ul,
 li ol {
@@ -211,7 +324,6 @@ li ol {
     text-indent: 0;
   }
 }
-
 @media screen {
   .inverted, .inverted #wrapper {
     background: #222;
@@ -225,18 +337,21 @@ li ol {
     background: #1a1a1a !important;
   }
 
-  .inverted hr {
-    border-color: #999 !important;
-  }
-
   .inverted p, .inverted td, .inverted li, .inverted h1, .inverted h2, .inverted h3, .inverted h4, .inverted h5, .inverted h6, .inverted pre, .inverted code, .inverted th, .inverted .math, .inverted caption, .inverted dd, .inverted dt {
     color: #f9f9f9 !important;
   }
-
+  .inverted blockquote,
+  .inverted figure,
+  .inverted p>code,
+  .inverted ul>code,
+  .inverted hr {
+    border-color: #000;
+    background-color: #111;
+    color: #f9f9f9;
+  }
   .inverted table tr:nth-child(odd), .inverted table th:nth-child(odd), .inverted table td:nth-child(odd) {
     background: none;
   }
-
   .inverted a {
     color: #ff5778;
   }
@@ -244,136 +359,6 @@ li ol {
 .max-width {
   max-width: 100%;
   height: auto;
-}
-/* ::Base styles Almost exclusively single element selectors */
-/* ------------------------------------------------------------ */
-html {
-  font-size: 100%;
-}
-body {
-  font: 100%/1.388 AvenirNext-Regular, Futura, "Century Gothic", AppleGothic, Corbel, "Myriad Pro", "Lucida Grande", "Trebuchet Ms", sans-serif;
-  color: #111;
-  padding: 0 5% 1rem !important;
-}
-a {
-  color: crimson;
-}
-a:hover, a:focus, a:active {
-  color: #ff2450;
-}
-h1, h2, h3, h4, h5, h6 {
-  font-family: AvenirNextCondensed-DemiBold, AvenirNext-Regular, Avenir-Black, Futura, "Century Gothic", AppleGothic, Corbel, "Myriad Pro", "Lucida Grande", "Trebuchet Ms", sans-serif;
-  margin: 0;
-  padding: .5em 0 0;
-}
-h2, h3, h4, h5 {
-  border-bottom: 2px solid #888;
-}
-}
-h1 {
-  font-size: 2.25rem;
-  line-height: 1.11111;
-}
-h2 {
-  font-size: 1.875rem;
-  line-height: 1.33333;
-}
-h3 {
-  font-size: 1.375rem;
-  line-height: 1.45455;
-}
-h4 {
-  font-size: 1.25rem;
-  line-height: 1.2;
-}
-h5 {
-  font-size: 1.125rem;
-  line-height: 1.33333;
-}
-h6 {
-  font-size: 1rem;
-  line-height: 1.5;
-}
-pre, label {
-  font-size: 1rem;
-  line-height: 1.5;
-}
-p {
-  font-size: 1.388rem;
-  line-height: 1.33333;
-  margin: 0 1em;
-  padding: .5em 0;
-  max-width: 30em;
-}
-h2 + p,
-h3 + p,
-h4 + p,
-h5 + p {
-  padding-top: .125em;
-  margin-top: 1px;
-  border-top: 1px solid #888;
-}
-ol, ul {
-  font-size: 1rem;
-  line-height: 1.5;
-  margin: 0 0 2em -1rem;
-}
-ul ul,ul ol {
-  margin-bottom: .4em;
-}
-ul {
-  list-style-position: outside;
-  list-style-type: square;
-}
-ol {
-  list-style-position: outside;
-  list-style-type: decimal;
-}
-pre {
-  display: block;
-  margin: 1.4em auto;
-  padding: .5em 1em 1em;
-  border-radius: 3px;
-  font-family: Consolas, Menlo, Monaco, monospace !important;
-  font-size: .875rem;
-  max-width: 90%;
-}
-code {
-  font-family: Consolas, Menlo, Monaco, monospace;
-}
-
-strong, b, dt {
-  font-family: AvenirNext-Medium, AvenirNext-Bold, AvenirNextCondensed-DemiBold, Avenir-Black, Futura, "Century Gothic", AppleGothic, Corbel, "Myriad Pro", "Lucida Grande", "Trebuchet Ms", sans-serif;
-  font-weight: 600;
-}
-em, q, blockquote, blockquote p  {
-  font-family: AvenirNext-MediumItalic, AvenirNext-BoldItalic, Avenir-MediumOblique, Futura, "Century Gothic", AppleGothic, Corbel, "Myriad Pro", "Lucida Grande", "Trebuchet Ms", sans-serif;
-  font-style: italic;
-}
-i {
-  font-family: AvenirNext-Italic, Avenir-Oblique, Futura, "Century Gothic", AppleGothic, Corbel, "Myriad Pro", "Lucida Grande", "Trebuchet Ms", sans-serif;
-  font-style: italic;
-}
-blockquote {
-  padding-left: 1em;
-  border-left: 0.3125em solid #c0c0c0;
-  line-height: normal;
-  /* margin: 0; */
-}
-blockquote p {
-  font-style: italic;
-  font-size: 1.25rem;
-  line-height: 1.2;
-  margin: 1.2em 0 1.2em 0;
-}
-img {
- padding: 1em;
- background-color: #e6e6e6;
- border: 1px solid #ddd;
- -webkit-border-radius: 3px;
- -moz-border-radius: 3px;
- -o-border-radius: 3px;
- border-radius: 3px;
 }
 
 @media screen and (max-width: 750px) {


### PR DESCRIPTION
Besides some small improvements (_, like getting rid of the bottom-borders on headings, better tables, and more_), main reason for this pull request is allowing the user to decide the rendered width of the text _in preferences_; before there was this set `max-width: 30em` on the `<p>`-tag in the stylesheet, which feels redundant in the preview-app environment, because of this preference-option :+1:  (_which I somehow wasn't aware of before :)_
