### PR TITLE
Improvements to Academica style

### DIFF
--- a/Academia.css
+++ b/Academia.css
@@ -78,6 +78,14 @@ body,p,td,div {
     word-wrap: break-word;
 }
 
+p {
+    text-indent: 2em;
+}
+
+blockquote + p {
+    text-indent: 0em;
+}
+
 h1,h2,h3,h4,h5,h6 {
     line-height: 1.5em;
 }
@@ -98,7 +106,7 @@ a:hover {
 
 .footnote {
     color: #0d6ea1;
-    font-size: .8em;
+    font-size: .83em;
     vertical-align: super;
 }
 
@@ -217,21 +225,24 @@ figure:hover>figcaption {
 
 .poetry pre {
     display: block;
-    font-family: Georgia, Garamond, serif !important;
-    font-size: 110% !important;
+    font-family: "Hoefler Text", Georgia, Garamond, serif !important;
+    font-size: .83em !important;
     font-style: normal;
     line-height: 1.6em;
     margin-left: 1em;
-}
+    text-indene: 0em;
 
 .poetry pre code {
-    font-family: Georgia, Garamond, serif !important;
+    font-family: "Hoefler Text", Georgia, Garamond, serif !important;
+    font-size: .83em !important;
+    text-indent: 0em;
 }
 
 blockquote p {
-    font-size: 110%;
+    font-size: .83em;
     font-style: normal;
     line-height: 1.6em;
+    text-indent: 0em;
 }
 
 .footnoteRef sup,sub {
@@ -242,6 +253,11 @@ blockquote p {
     position: relative;
     vertical-align: super;
     padding-left: 0.35ex;
+}
+
+div.references,div#references {
+    padding-left: 2em;
+    text-indent: -2em;
 }
 
 sub {

--- a/Academia.css
+++ b/Academia.css
@@ -1,4 +1,4 @@
-/* 
+/*
    This document has been created with Marked.app <http://markedapp.com>, Copyright 2011 Brett Terpstra
    Please leave this notice in place, along with any additional credits below.
    ---------------------------------------------------------------
@@ -256,7 +256,7 @@ blockquote p {
     padding-left: 0.35ex;
 }
 
-div.references,div#references {
+div.references>p,div#references>p {
     padding-left: 2em;
     text-indent: -2em;
 }

--- a/Academia.css
+++ b/Academia.css
@@ -86,6 +86,10 @@ blockquote + p {
     text-indent: 0em;
 }
 
+h1+p,h2+p,h3+p,h4+p,h5+p,h6+p {
+    text-indent: 0em;
+}
+
 h1,h2,h3,h4,h5,h6 {
     line-height: 1.5em;
 }

--- a/Academia.css
+++ b/Academia.css
@@ -10,7 +10,7 @@ body {
     -webkit-font-smoothing: antialiased;
     font-style: normal;
     font-size: 12pt;
-    font-family; "Hoefler Text", Palatino, Georgia, Times, Serif;
+    font-family: "Hoefler Text", Palatino, Georgia, Times, Serif;
 	text-align: justify;
 	hyphens: auto;
 	width: 825px;
@@ -231,6 +231,7 @@ figure:hover>figcaption {
     line-height: 1.6em;
     margin-left: 1em;
     text-indene: 0em;
+}
 
 .poetry pre code {
     font-family: "Hoefler Text", Georgia, Garamond, serif !important;

--- a/Academia.css
+++ b/Academia.css
@@ -260,7 +260,7 @@ blockquote p {
     padding-left: 0.35ex;
 }
 
-div.references>p,div#references>p {
+div.refs>p,div#refs>p {
     padding-left: 2em;
     text-indent: -2em;
 }


### PR DESCRIPTION
1. Indent paragraphs which do not follow blocked quotations
2. Make size of text in blocked quotations smaller in line with advice of most style guides (Chicago, MLA, MHRA). 0.83em corresponds with the decrease from 12pt to 10pt. Change footnote size to correspond with this.
3. Add hanging indent to bibliography/references, and add future-proofed support for upcoming changes in pandoc from class=“references” to id=“references”.

