### PR TITLE
fix broken code + tt padding css in github-updated.css

### DIFF
--- a/github-updated.css
+++ b/github-updated.css
@@ -515,9 +515,7 @@ code, tt {
   border-radius: 3px;
   font-size: 85%;
   margin: 0;
-  padding-bottom: .2em;
-  padding-top: .2em;
-  padding: .4 .2;
+  padding: .2em .4em;
 }
 
 code::before, code::after {


### PR DESCRIPTION
fix broken css in [github-updated.css](https://github.com/ttscoff/MarkedCustomStyles/blob/9f899c10fcc23f60f7b0a6a5b89f11418e3b7615/github-updated.css#L520), making it match [current GH](https://github.githubassets.com/assets/behaviors-ded0d7c8e2c71e06a744.css) `.markdown-body code, .markdown-body tt` padding (`.2em .4em`).

cc @luispuerto